### PR TITLE
Add `GatewayRequest.drain()` to copy stack to output for better testing

### DIFF
--- a/contracts/GatewayProver.sol
+++ b/contracts/GatewayProver.sol
@@ -205,7 +205,7 @@ library GatewayProver {
 		vm.target = address(0);
 		vm.storageRoot = NOT_A_CONTRACT;
 		vm.slot = 0;
-		outputs = new bytes[](vm.readByte());
+		outputs = new bytes[](vm.readByte()); // NOTE: implies maximum outputs is 255
 		exitCode = evalCommand(vm, outputs);
 	}
 

--- a/src/eth/merkle.ts
+++ b/src/eth/merkle.ts
@@ -2,7 +2,7 @@ import type { HexString, BigNumberish } from '../types.js';
 import type { EthProof } from './types.js';
 import { ZeroHash } from 'ethers/constants';
 import { keccak256 } from 'ethers/crypto';
-import { decodeRlp, zeroPadValue } from 'ethers/utils';
+import { decodeRlp } from 'ethers/utils';
 import { toPaddedHex } from '../utils.js';
 
 // https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md
@@ -53,7 +53,7 @@ export function proveStorageValue(
   if (!rlp) return ZeroHash;
   const decoded = decodeRlp(rlp);
   if (typeof decoded !== 'string') throw new Error('invalid storage value');
-  return zeroPadValue(decoded, 32);
+  return toPaddedHex(decoded);
 }
 
 // same arg order as MerkleTrie.get()

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -256,11 +256,11 @@ export class GatewayProgram {
   plus() {
     return this.addByte(OP.PLUS);
   }
-  negate() {
+  complement() {
     return this.not().push(1).plus(); // twos complement
   }
   subtract() {
-    return this.negate().plus();
+    return this.complement().plus();
   }
   times() {
     return this.addByte(OP.TIMES);

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -8,7 +8,7 @@ import type {
   ProofSequenceV1,
   Provider,
 } from './types.js';
-import { ZeroAddress, ZeroHash, MaxUint256 } from 'ethers/constants';
+import { ZeroAddress, ZeroHash } from 'ethers/constants';
 import { Contract } from 'ethers/contract';
 import { Interface } from 'ethers/abi';
 import { keccak256 } from 'ethers/crypto';
@@ -256,8 +256,11 @@ export class GatewayProgram {
   plus() {
     return this.addByte(OP.PLUS);
   }
+  negate() {
+    return this.not().push(1).plus(); // twos complement
+  }
   subtract() {
-    return this.push(MaxUint256).plus().not().plus(); // TODO: add op?
+    return this.negate().plus();
   }
   times() {
     return this.addByte(OP.TIMES);

--- a/test/components/ops.test.ts
+++ b/test/components/ops.test.ts
@@ -108,10 +108,15 @@ describe('ops', async () => {
   });
 
   test('setSlot', async () => {
-    const slot = 1337n;
-    const req = new GatewayRequest().push(slot).slot();
-    const state = await verify(req);
-    expect(state.slot).toEqual(slot);
+    const req = new GatewayRequest().push(123).slot().pushSlot().addOutput();
+    const { values } = await verify(req);
+    expect(values[0]).toEqual(toPaddedHex(123));
+  });
+
+  test('addSlot', async () => {
+    const req = new GatewayRequest().push(123).addSlot().pushSlot().addOutput();
+    const { values } = await verify(req);
+    expect(values[0]).toEqual(toPaddedHex(123));
   });
 
   test('keccak', async () => {


### PR DESCRIPTION
- Add `GatewayRequest.drain()` &mdash; future idea: `OP_STACK_SIZE`
- Change tests using `stack` and `slot` to `outputs` w/`drain()`
- Simplify `subtract()` and add `complement()`
- Few miscellaneous cleanups