### PR TITLE
Change `BASE` to `OPFaultRollup` / Fix `TrustedRollup` Types

### DIFF
--- a/contracts/GatewayVM.sol
+++ b/contracts/GatewayVM.sol
@@ -55,10 +55,11 @@ library GatewayVM {
             let e := add(p, mload(v)) // end of v
             let x
             ret := 1 // assume zero
+            // while (p < e)
             for {
 
             } lt(p, e) {
-                // while (p < e)
+
             } {
                 x := mload(p) // remember last
                 p := add(p, 32) // step by word

--- a/contracts/ReadBytesAt.sol
+++ b/contracts/ReadBytesAt.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 contract ReadBytesAt {
-    // NOTE: pure seems like the wrong mutability annotation
+    // NOTE: pure is the wrong mutability annotation but because of the direct use of inline assembly to set v.slot, Solidity can’t verify that it’s only reading storage and not modifying it
     function readBytesAt(uint256 slot) external pure returns (bytes memory) {
         bytes storage v;
         assembly {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unruggable/gateways",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Trustless Ethereum Multichain CCIP-Read Gateway",
   "publishConfig": {
     "access": "public"

--- a/scripts/serve.ts
+++ b/scripts/serve.ts
@@ -295,7 +295,6 @@ async function createGateway(name: string) {
       return new Gateway(new ZKSyncRollup(createProviderPair(config), config));
     }
     case 'base':
-      // return createOPGateway(OPRollup.baseMainnetConfig);
       return createOPFaultGateway(OPFaultRollup.baseMainnetConfig);
     case 'base-sepolia':
       return createOPFaultGateway(OPFaultRollup.baseSepoliaConfig);

--- a/scripts/serve.ts
+++ b/scripts/serve.ts
@@ -20,11 +20,10 @@ import { EthSelfRollup } from '../src/eth/EthSelfRollup.js';
 import { Contract } from 'ethers/contract';
 import { SigningKey } from 'ethers/crypto';
 import { toUnpaddedHex } from '../src/utils.js';
-import { TrustedRollup } from '../src/eth/TrustedRollup.js';
+import { TrustedRollup } from '../src/TrustedRollup.js';
 import { EthProver } from '../src/eth/EthProver.js';
 //import { LineaProver } from '../src/linea/LineaProver.js';
 import { ZKSyncProver } from '../src/zksync/ZKSyncProver.js';
-import { AbstractProver, type LatestProverFactory } from '../src/vm.js';
 
 // NOTE: you can use CCIPRewriter to test an existing setup against a local gateway!
 // [raffy] https://adraffy.github.io/ens-normalize.js/test/resolver.html#raffy.linea.eth.nb2hi4dthixs62dpnvss4ylooruxg5dvobuwiltdn5ws62duoryc6.ccipr.eth
@@ -180,13 +179,22 @@ async function createGateway(name: string) {
     const slug = match[1].toUpperCase().replaceAll('-', '_');
     if (slug in CHAINS) {
       const chain = CHAINS[slug as keyof typeof CHAINS];
-      return new Gateway(
-        new TrustedRollup(
-          createProvider(chain),
-          getProverFactory(chain),
-          new SigningKey(signingKey)
-        )
-      );
+      const provider = createProvider(chain);
+      const key = new SigningKey(signingKey);
+      switch (chain) {
+        case CHAINS.ZKSYNC:
+        case CHAINS.ZKSYNC_SEPOLIA:
+          return new Gateway(new TrustedRollup(provider, ZKSyncProver, key));
+        // NOTE: linea should use eth_getProof instead of linea_getProof
+        // NOTE: this probably needs "--latest" cli option too
+        // rollup => SMT w/Mimc root using linea_getProof
+        // chain => PMT w/Keccak root using eth_getProof
+        // case CHAINS.LINEA:
+        // case CHAINS.LINEA_SEPOLIA:
+        //   return LineaProver;
+        default:
+          return new Gateway(new TrustedRollup(provider, EthProver, key));
+      }
     }
   }
   switch (name) {
@@ -287,7 +295,8 @@ async function createGateway(name: string) {
       return new Gateway(new ZKSyncRollup(createProviderPair(config), config));
     }
     case 'base':
-      return createOPGateway(OPRollup.baseMainnetConfig);
+      // return createOPGateway(OPRollup.baseMainnetConfig);
+      return createOPFaultGateway(OPFaultRollup.baseMainnetConfig);
     case 'base-sepolia':
       return createOPFaultGateway(OPFaultRollup.baseSepoliaConfig);
     case 'unfinalized-base-sepolia':
@@ -334,23 +343,6 @@ async function createGateway(name: string) {
       return createSelfGateway(CHAINS.HOLESKY);
     default:
       throw new Error(`unknown gateway: ${name}`);
-  }
-}
-
-function getProverFactory(chain: Chain): LatestProverFactory<AbstractProver> {
-  switch (chain) {
-    case CHAINS.ZKSYNC:
-    case CHAINS.ZKSYNC_SEPOLIA:
-      return ZKSyncProver;
-    // NOTE: linea should use eth_getProof instead of linea_getProof
-    // NOTE: this probably needs "--latest" cli option too
-    // rollup => SMT w/Mimc root using linea_getProof
-    // chain => PMT w/Keccak root using eth_getProof
-    // case CHAINS.LINEA:
-    // case CHAINS.LINEA_SEPOLIA:
-    //   return LineaProver;
-    default:
-      return EthProver;
   }
 }
 

--- a/src/TrustedRollup.ts
+++ b/src/TrustedRollup.ts
@@ -3,12 +3,12 @@ import type {
   HexString32,
   ProofSequence,
   Provider,
-} from '../types.js';
-import { AbstractProver, type LatestProverFactory } from '../vm.js';
-import { AbstractRollup, type RollupCommit } from '../rollup.js';
-import { ABI_CODER } from '../utils.js';
-import { CachedValue } from '../cached.js';
-import { VOID_PROVIDER } from '../VoidProvider.js';
+} from './types.js';
+import type { AbstractProver, LatestProverFactory } from './vm.js';
+import { AbstractRollup, type RollupCommit } from './rollup.js';
+import { ABI_CODER } from './utils.js';
+import { CachedValue } from './cached.js';
+import { VOID_PROVIDER } from './VoidProvider.js';
 import { ZeroAddress } from 'ethers/constants';
 import { SigningKey } from 'ethers/crypto';
 import { computeAddress } from 'ethers/transaction';
@@ -30,7 +30,7 @@ export class TrustedRollup<P extends AbstractProver> extends AbstractRollup<
     readonly signingKey: SigningKey
   ) {
     super({ provider1: VOID_PROVIDER, provider2 });
-    this.latest = new CachedValue<TrustedCommit<P>>(async () => {
+    this.latest = new CachedValue(async () => {
       const prover = await factory.latest(this.provider2, this.latestBlockTag);
       const stateRoot = await prover.fetchStateRoot();
       const signedAt = Math.ceil(Date.now() / 1000);
@@ -57,8 +57,9 @@ export class TrustedRollup<P extends AbstractProver> extends AbstractRollup<
     return -1n;
   }
   protected override async _fetchCommit(
-    _index: bigint
+    index: bigint
   ): Promise<TrustedCommit<P>> {
+    if (index) throw new Error('unsupported commit');
     return this.latest.get();
   }
   override encodeWitness(

--- a/src/eth/EthProver.ts
+++ b/src/eth/EthProver.ts
@@ -13,7 +13,8 @@ import { withResolvers, toPaddedHex } from '../utils.js';
 export class EthProver extends BlockProver {
   static readonly encodeProof = encodeProof;
   static readonly isContract = isContract;
-  override async isContract(target: HexAddress) {
+  static readonly latest = this._createLatest();
+  override async isContract(target: HexAddress): Promise<boolean> {
     target = target.toLowerCase();
     if (this.fast) {
       return this.cache.get(target, async () => {

--- a/src/eth/EthSelfRollup.ts
+++ b/src/eth/EthSelfRollup.ts
@@ -1,6 +1,6 @@
 import type { HexString, ProofSequence, Provider } from '../types.js';
 import { AbstractRollup, type RollupCommit } from '../rollup.js';
-import { ABI_CODER, fetchBlock, MAINNET_BLOCK_SEC } from '../utils.js';
+import { fetchBlockNumber, ABI_CODER, MAINNET_BLOCK_SEC } from '../utils.js';
 import { EthProver } from './EthProver.js';
 import { encodeRlpBlock } from '../rlp.js';
 
@@ -23,8 +23,9 @@ export class EthSelfRollup extends AbstractRollup<EthSelfCommit> {
     return index - (index % this.commitStep);
   }
   override async fetchLatestCommitIndex(): Promise<bigint> {
-    const blockInfo = await fetchBlock(this.provider1, this.latestBlockTag);
-    return this.align(BigInt(blockInfo.number));
+    return this.align(
+      await fetchBlockNumber(this.provider1, this.latestBlockTag)
+    );
   }
   protected override async _fetchParentCommitIndex(
     commit: EthSelfCommit

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './utils.js';
 export * from './rlp.js';
 export * from './chains.js';
 export * from './VoidProvider.js';
+export * from './GatewayProvider.js';
 
 //export * from './ops.js'; use GatewayRequest.Opcodes instead
 export * from './reader.js';
@@ -34,7 +35,7 @@ export * from './taiko/TaikoRollup.js';
 export * from './scroll/ScrollRollup.js';
 export * from './zksync/ZKSyncRollup.js';
 export * from './eth/EthSelfRollup.js';
-export * from './eth/TrustedRollup.js';
+export * from './TrustedRollup.js';
 
 export * from './gateway.js';
 export * from './linea/LineaGatewayV1.js';

--- a/src/op/OPFaultRollup.ts
+++ b/src/op/OPFaultRollup.ts
@@ -37,7 +37,6 @@ export class OPFaultRollup extends AbstractOPRollup {
     OptimismPortal: '0xbEb5Fc579115071764c7423A4f12eDde41f106Ed',
     GameFinder: GAME_FINDER_MAINNET,
   };
-
   static readonly sepoliaConfig: RollupDeployment<OPFaultConfig> = {
     chain1: CHAINS.SEPOLIA,
     chain2: CHAINS.OP_SEPOLIA,
@@ -45,6 +44,13 @@ export class OPFaultRollup extends AbstractOPRollup {
     GameFinder: GAME_FINDER_SEPOLIA,
   };
 
+  // https://docs.base.org/docs/base-contracts#l1-contract-addresses
+  static readonly baseMainnetConfig: RollupDeployment<OPFaultConfig> = {
+    chain1: CHAINS.MAINNET,
+    chain2: CHAINS.BASE,
+    OptimismPortal: '0x49048044D57e1C92A77f79988d21Fa8fAF74E97e',
+    GameFinder: GAME_FINDER_MAINNET,
+  };
   // https://docs.base.org/docs/base-contracts/#ethereum-testnet-sepolia
   static readonly baseSepoliaConfig: RollupDeployment<OPFaultConfig> = {
     chain1: CHAINS.SEPOLIA,

--- a/src/op/OPRollup.ts
+++ b/src/op/OPRollup.ts
@@ -10,12 +10,12 @@ export type OPConfig = {
 };
 
 export class OPRollup extends AbstractOPRollup {
-  // https://docs.base.org/docs/base-contracts#base-mainnet
-  static readonly baseMainnetConfig: RollupDeployment<OPConfig> = {
-    chain1: CHAINS.MAINNET,
-    chain2: CHAINS.BASE,
-    L2OutputOracle: '0x56315b90c40730925ec5485cf004d835058518A0',
-  };
+  // 20241030: base changed to fault proofs
+  // static readonly baseMainnetConfig: RollupDeployment<OPConfig> = {
+  //   chain1: CHAINS.MAINNET,
+  //   chain2: CHAINS.BASE,
+  //   L2OutputOracle: '0x56315b90c40730925ec5485cf004d835058518A0',
+  // };
 
   // https://docs.blast.io/building/contracts#mainnet
   static readonly blastMainnnetConfig: RollupDeployment<OPConfig> = {

--- a/src/polygon/ZKEVMProver.ts
+++ b/src/polygon/ZKEVMProver.ts
@@ -13,6 +13,7 @@ import {
 export class ZKEVMProver extends BlockProver {
   static readonly isContract = isContract;
   static readonly encodeProof = encodeProof;
+  static readonly latest = this._createLatest();
   override async isContract(target: HexAddress): Promise<boolean> {
     target = target.toLowerCase();
     if (this.fast) {

--- a/src/zksync/ZKSyncProver.ts
+++ b/src/zksync/ZKSyncProver.ts
@@ -43,7 +43,8 @@ export class ZKSyncProver extends AbstractProver {
     return batchIndex + Number(relative); //(typeof relative === 'string' ? 0 : Number(relative));
   }
   static async latest(provider: Provider, relative: BigNumberish = 0) {
-    return new this(provider, await this.latestBatchIndex(provider, relative));
+    const batchIndex = await this.latestBatchIndex(provider, relative);
+    return new this(provider, batchIndex);
   }
   constructor(
     provider: Provider,

--- a/src/zksync/ZKSyncProver.ts
+++ b/src/zksync/ZKSyncProver.ts
@@ -43,8 +43,7 @@ export class ZKSyncProver extends AbstractProver {
     return batchIndex + Number(relative); //(typeof relative === 'string' ? 0 : Number(relative));
   }
   static async latest(provider: Provider, relative: BigNumberish = 0) {
-    const batchIndex = await this.latestBatchIndex(provider, relative);
-    return new this(provider, batchIndex);
+    return new this(provider, await this.latestBatchIndex(provider, relative));
   }
   constructor(
     provider: Provider,

--- a/test/debug/play.ts
+++ b/test/debug/play.ts
@@ -1,9 +1,20 @@
-import { GatewayRequestV1, GatewayRequest, EthProver, CHAINS,  NitroRollup, OPRollup, TaikoRollup, ZKSyncRollup, fetchBlockNumber } from '../../src/index.js';
+import { randomBytes, SigningKey, ZeroHash } from 'ethers';
+import { GatewayRequestV1, GatewayRequest, EthProver, CHAINS,  NitroRollup, OPRollup, TaikoRollup, ZKSyncRollup, fetchBlockNumber, TrustedRollup, ZKEVMProver, ZKSyncProver, LineaProver, OPFaultRollup } from '../../src/index.js';
 import { createProvider, createProviderPair } from '../providers.js';
 
 // this is just a worksheet
 
 //console.log(createProvider(1n)._getConnection())
+
+if (1) {
+	const provider = createProvider(CHAINS.MAINNET);
+	const key = new SigningKey(randomBytes(32));
+	const rollup1 = new TrustedRollup(provider, EthProver, key);
+	const rollup2 = new TrustedRollup(provider, ZKSyncProver, key);
+	const rollup3 = new TrustedRollup(provider, LineaProver, key);
+	const rollup4 = new TrustedRollup(provider, ZKEVMProver, key);
+	throw 1;
+}
 
 if (1) {
 	const provider = createProvider(CHAINS.OP_SEPOLIA);
@@ -31,8 +42,8 @@ if (0) {
 
 
 if (0) {
-	const config = OPRollup.baseMainnetConfig;
-	const rollup = new OPRollup(createProviderPair(config), config);
+	const config = OPFaultRollup.baseMainnetConfig;
+	const rollup = new OPFaultRollup(createProviderPair(config), config);
 	//const commit = await rollup.fetchLatestCommit();
 	const commit = await rollup.fetchCommit(0n);
 	console.log(commit);

--- a/test/debug/proxy.ts
+++ b/test/debug/proxy.ts
@@ -11,29 +11,41 @@ import { Foundry } from '@adraffy/blocksmith';
 //   return new Contract(proxy.target, verifier.interface, wallet);
 // }
 
-const foundry = await Foundry.launch();
+const foundry = await Foundry.launch({ infoLog: true, procLog: true });
 
 const ownerWallet = await foundry.ensureWallet('owner');
 
+const GatewayVM = await foundry.deploy({ file: 'GatewayVM' });
 const impl = await foundry.deploy({
   file: 'OPFaultVerifier',
-  args: [ZeroAddress],
+  args: [
+    [],
+    0,
+    ZeroAddress,
+    [
+      ZeroAddress,
+      ZeroAddress,
+      0,
+      1,
+    ],
+  ],
+  libs: { GatewayVM },
+  from: ownerWallet
 });
 
 const proxy = await foundry.deploy({
   import: '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol',
-  args: [impl, ownerWallet, '0x'],
+  args: [impl, ownerWallet.address, '0x'],
+  from: ownerWallet
 });
 
-const verifier = new Contract(proxy, impl.interface, ownerWallet);
-
-console.log(await verifier.owner());
+console.log(await impl.owner());
 console.log(ownerWallet.address);
 
-await foundry.confirm(verifier.setGatewayURLs(['chonk.com']));
-console.log(await verifier.gatewayURLs());
+await foundry.confirm(impl.setGatewayURLs(['chonk.com']));
+console.log(await impl.gatewayURLs());
 
-await foundry.confirm(verifier.setWindow(69420));
-console.log(await verifier.getWindow());
+//20241101 We don't use a proxy pattern any longer and access control means you can't interface with a verifier through a proxy.
+const verifierThroughProxy = new Contract(proxy, impl.interface, ownerWallet);
 
 await foundry.shutdown();

--- a/test/debug/serve-list.ts
+++ b/test/debug/serve-list.ts
@@ -1,6 +1,6 @@
 import {readFileSync} from 'node:fs';
 
-const code = readFileSync(new URL('../serve.ts', import.meta.url), {encoding: 'utf8'});
+const code = readFileSync(new URL('../../scripts/serve.ts', import.meta.url), {encoding: 'utf8'});
 
 const { index } = code.match(/function createGateway\(/)!;
 const names: string[] = [];

--- a/test/debug/speed.ts
+++ b/test/debug/speed.ts
@@ -1,7 +1,7 @@
 import { OPRollup } from "../../src/op/OPRollup.js";
 import { createProviderPair } from "../providers.js";
 
-const config = OPRollup.baseMainnetConfig;
+const config = OPRollup.zoraMainnetConfig;
 const rollup = new OPRollup(createProviderPair(config), config);
 
 const commit = await logTime('fetchLatestCommit', rollup.fetchLatestCommit());

--- a/test/gateway/base.test.ts
+++ b/test/gateway/base.test.ts
@@ -1,7 +1,10 @@
-import { OPRollup } from '../../src/op/OPRollup.js';
-import { testOP } from './common.js';
+import { OPFaultRollup } from '../../src/op/OPFaultRollup.js';
+import { testOPFault } from './common.js';
 
-testOP(OPRollup.baseMainnetConfig, {
+// 20241030: base changed to fault proofs
+// https://base.mirror.xyz/eOsedW4tm8MU5OhdGK107A9wsn-aU7MAb8f3edgX5Tk
+// https://twitter.com/base/status/1851672364439814529
+testOPFault(OPFaultRollup.baseMainnetConfig, {
   // https://basescan.org/address/0x0C49361E151BC79899A9DD31B8B0CCdE4F6fd2f6
   slotDataContract: '0x0C49361E151BC79899A9DD31B8B0CCdE4F6fd2f6',
 });

--- a/test/gateway/common.ts
+++ b/test/gateway/common.ts
@@ -20,7 +20,7 @@ import {
   ScrollRollup,
 } from '../../src/scroll/ScrollRollup.js';
 import { EthSelfRollup } from '../../src/eth/EthSelfRollup.js';
-import { TrustedRollup } from '../../src/eth/TrustedRollup.js';
+import { TrustedRollup } from '../../src/TrustedRollup.js';
 import { EthProver } from '../../src/eth/EthProver.js';
 import { randomBytes, SigningKey } from 'ethers/crypto';
 import { afterAll } from 'bun:test';

--- a/test/gateway/delayed-zora.test.ts
+++ b/test/gateway/delayed-zora.test.ts
@@ -1,9 +1,9 @@
 import { OPRollup } from '../../src/op/OPRollup.js';
 import { testOP } from './common.js';
 
-testOP(OPRollup.baseMainnetConfig, {
-  // https://basescan.org/address/0x0C49361E151BC79899A9DD31B8B0CCdE4F6fd2f6
-  slotDataContract: '0x0C49361E151BC79899A9DD31B8B0CCdE4F6fd2f6',
+testOP(OPRollup.zoraMainnetConfig, {
+  // https://explorer.zora.energy/address/0x73404681064a8e16c22C1411A02D47e6395f6582
+  slotDataContract: '0x73404681064a8e16c22C1411A02D47e6395f6582',
   // delay by 1 hour
   // NOTE: to delay longer, Gateway.commitDepth needs to be bigger
   minAgeSec: 3600,

--- a/test/rollup/base.ts
+++ b/test/rollup/base.ts
@@ -1,11 +1,13 @@
-import { OPRollup } from '../../src/op/OPRollup.js';
+import { OPFaultRollup } from '../../src/op/OPFaultRollup.js';
 import { createProviderPair } from '../providers.js';
 
-const config = OPRollup.baseMainnetConfig;
-const rollup = new OPRollup(createProviderPair(config), config);
+const config = OPFaultRollup.baseMainnetConfig;
+const rollup = new OPFaultRollup(createProviderPair(config), config);
 
 console.log({
-  L2OutputOracle: rollup.L2OutputOracle.target,
+  OptimismPortal: rollup.OptimismPortal.target,
+  GameFinder: rollup.GameFinder.target,
+  respectedGameType: await rollup.fetchRespectedGameType(),
   defaultWindow: rollup.defaultWindow,
 });
 
@@ -15,5 +17,10 @@ const v = commits.map((x) => Number(x.index));
 console.log(v);
 console.log(v.slice(1).map((x, i) => v[i] - x));
 
+// (OLD: OPRollup)
 // [ 10444, 10443, 10442, 10441, 10440, 10439, 10438, 10437, 10436, 10435 ]
 // [ 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+
+// (NEW: OPFaultRollup)
+// [ 6, 2, 0 ]
+// [ 4, 2 ]

--- a/test/rollup/trusted.ts
+++ b/test/rollup/trusted.ts
@@ -1,6 +1,6 @@
 import { randomBytes, SigningKey } from 'ethers/crypto';
 import { CHAINS } from '../../src/chains.js';
-import { TrustedRollup } from '../../src/eth/TrustedRollup.js';
+import { TrustedRollup } from '../../src/TrustedRollup.js';
 import { EthProver } from '../../src/index.js';
 import { createProvider } from '../providers.js';
 

--- a/test/rollup/zora.ts
+++ b/test/rollup/zora.ts
@@ -1,0 +1,19 @@
+import { OPRollup } from '../../src/op/OPRollup.js';
+import { createProviderPair } from '../providers.js';
+
+const config = OPRollup.zoraMainnetConfig;
+const rollup = new OPRollup(createProviderPair(config), config);
+
+console.log({
+  L2OutputOracle: rollup.L2OutputOracle.target,
+  defaultWindow: rollup.defaultWindow,
+});
+
+const commits = await rollup.fetchRecentCommits(10);
+
+const v = commits.map((x) => Number(x.index));
+console.log(v);
+console.log(v.slice(1).map((x, i) => v[i] - x));
+
+// [ 12367, 12366, 12365, 12364, 12363, 12362, 12361, 12360, 12359, 12358 ]
+// [ 1, 1, 1, 1, 1, 1, 1, 1, 1 ]


### PR DESCRIPTION
* change `BASE` from `OPRollup` to `OPFaultRollup`
* change `OPRollup` examples using `BASE` to `ZORA`
* moved `TrustedRollup` out of /eth/ since it works for all chains
* fixed `new TrustedRollup(..., Prover, ...)` type
    * could not figure out how to do it [the way I wanted](https://twitter.com/adraffy/status/1851840343496380532)
    * using explicit static constructor on each implementation
    * `BlockProver` has `_createFactory()` factory generator
* fixed `TrustedRollup` interaction with call cache
    * permanent `index = 0` caused commit cache to fill up with expired signatures
    * new design uses increasing `index`