### PR TITLE
OPFault Canary Fix

### DIFF
--- a/src/eth/EthProver.ts
+++ b/src/eth/EthProver.ts
@@ -152,6 +152,7 @@ export class EthProver extends BlockProver {
       if (i >= slots.length) break;
     }
     const vs = await Promise.all(ps);
+    if (!vs[0]) throw new Error(`unprovable block: ${this.block}`);
     for (let i = 1; i < vs.length; i++) {
       vs[0].storageProof.push(...vs[i].storageProof);
     }

--- a/src/op/OPFaultRollup.ts
+++ b/src/op/OPFaultRollup.ts
@@ -3,6 +3,7 @@ import type { HexAddress, HexString32, ProviderPair } from '../types.js';
 import { Contract } from 'ethers/contract';
 import { PORTAL_ABI, GAME_FINDER_ABI, GAME_ABI } from './types.js';
 import { CHAINS } from '../chains.js';
+import { isEthersError } from '../utils.js';
 import {
   AbstractOPRollup,
   hashOutputRootProof,
@@ -131,6 +132,7 @@ export class OPFaultRollup extends AbstractOPRollup {
           // canary often has invalid block <== likely triggers first
           // canary has invalid time
           // canary has invalid root claim
+          if (isEthersError(err)) throw err;
           index = await this.GameFinder.findGameIndex(
             this.OptimismPortal.target,
             this.minAgeSec,

--- a/src/op/types.ts
+++ b/src/op/types.ts
@@ -26,6 +26,10 @@ export const GAME_FINDER_ABI = new Interface([
    )`,
 ]);
 
+export const GAME_ABI = new Interface([
+  `function rootClaim() view returns (bytes32)`,
+]);
+
 export const L1_BLOCK_ABI = new Interface([
   `function number() view returns (uint256)`,
   //`function hash() view returns (bytes32)`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { AbiCoder } from 'ethers/abi';
 import { id as keccakStr } from 'ethers/hash';
+import type { EthersError } from 'ethers/utils';
 import type { Provider, BigNumberish, HexString } from './types.js';
 import type { RPCEthGetBlock } from './eth/types.js';
 
@@ -87,10 +88,13 @@ export async function fetchBlockTag(
     : fetchBlockNumber(provider, relBlockTag);
 }
 
-export function isRPCError(err: any, code: number) {
+export function isEthersError(err: any): err is EthersError {
+  return err instanceof Error && 'code' in err && 'shortMessage' in err;
+}
+
+export function isRPCError(err: any, code: number): err is EthersError {
   return (
-    err instanceof Error &&
-    'error' in err &&
+    isEthersError(err) &&
     err.error instanceof Object &&
     'code' in err.error &&
     err.error.code === code


### PR DESCRIPTION
* Unfinalized `OPFault` will check if `rootClaim` matches source chain
* Unfinalized `OPFault` commit indexing will skip invalid commits
* `EthProver` has RPC type check on `eth_getProof` and `eth_getStorageAt`
     * Alternative design: only allow prover to be constructed with valid block