### PR TITLE
Delay API

### DIFF
--- a/src/cached.ts
+++ b/src/cached.ts
@@ -35,9 +35,15 @@ export class CachedValue<T> {
   get value() {
     return this.#value;
   }
+  get isCached() {
+    return this.#exp > clock();
+  }
+  get cachedRemainingMs() {
+    return Math.max(0, clock() - this.#exp);
+  }
   async get() {
     if (this.#value) {
-      if (this.#exp > clock()) return this.#value;
+      if (this.isCached) return this.#value;
       this.#value = undefined;
     }
     const p = (this.#value = this.fn());

--- a/src/linea/LineaProver.ts
+++ b/src/linea/LineaProver.ts
@@ -15,8 +15,8 @@ import {
   encodeProof,
 } from './types.js';
 
-// BLOCK_MISSING_IN_CHAIN, UNKNOWN
-const TRANSIENT_RPC_ERRORS = new Set([-32600, -32603]);
+const BLOCK_MISSING_IN_CHAIN = -32600;
+const UNKNOWN_RPC_ERROR = -32603;
 
 export class LineaProver extends BlockProver {
   static readonly isInclusionProof = isInclusionProof;
@@ -34,7 +34,8 @@ export class LineaProver extends BlockProver {
       await this.getProofs(ZeroAddress);
       return true;
     } catch (err) {
-      if (isRPCError(err, TRANSIENT_RPC_ERRORS)) return false;
+      if (isRPCError(err, BLOCK_MISSING_IN_CHAIN, UNKNOWN_RPC_ERROR))
+        return false;
       throw err;
     }
   }

--- a/src/starknet/StarknetProver.ts
+++ b/src/starknet/StarknetProver.ts
@@ -64,16 +64,21 @@ export class StarknetProver extends AbstractProver {
     this.blockId = { block_number: block };
   }
   override get context() {
-    return `block=${this.blockNumber}`;
+    return { block: this.blockNumber };
   }
   get blockNumber() {
     return this.blockId.block_number;
   }
-  async fetchBlock(): Promise<RPCStarknetBlock> {
-    return this.provider.send('starknet_getBlockWithTxHashes', [this.blockId]);
+  fetchBlock(): Promise<RPCStarknetBlock> {
+    return this.cache.get('BLOCK', () =>
+      this.provider.send('starknet_getBlockWithTxHashes', [this.blockId])
+    );
   }
   override async fetchStateRoot(): Promise<HexString32> {
     return (await this.fetchBlock()).new_root;
+  }
+  override async fetchTimestamp() {
+    return (await this.fetchBlock()).timestamp;
   }
   override async isContract(
     target: HexString32,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,17 +134,13 @@ export function isRevert(err: unknown): err is CallExceptionError {
   return isEthersError(err) && err.code === 'CALL_EXCEPTION';
 }
 
-export function isRPCError(
-  err: any,
-  code: number | Set<number>
-): err is EthersError {
+export function isRPCError(err: any, ...code: number[]): err is EthersError {
   return (
     isEthersError(err) &&
     err.error instanceof Object &&
     'code' in err.error &&
-    (code instanceof Set
-      ? code.has(err.error.code as number)
-      : err.error.code === code)
+    typeof err.error.code === 'number' &&
+    code.includes(err.error.code)
   );
 }
 

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -529,10 +529,10 @@ export abstract class AbstractProver {
 
   constructor(readonly provider: Provider) {}
 
-  abstract get context(): string;
+  abstract get context(): Record<string, any>;
 
   [Symbol.for('nodejs.util.inspect.custom')]() {
-    return `${this.constructor.name}[${this.context}]`;
+    return `${this.constructor.name}[${Object.entries(this.context).map(([k, v]) => `${k}=${v}`)}]`;
   }
 
   checkProofCount(size: number) {
@@ -589,6 +589,7 @@ export abstract class AbstractProver {
   // a block-derived LineaProver doesn't have a stateRoot
   // whereas LineaRollup => getCommit() => prover does (from L1)
   abstract fetchStateRoot(): Promise<HexString32>;
+  abstract fetchTimestamp(): Promise<number>;
 
   // machine interface
   async evalDecoded(v: BytesLike) {
@@ -1010,16 +1011,19 @@ export abstract class BlockProver extends AbstractProver {
     this.block = toUnpaddedHex(block);
   }
   override get context() {
-    return `block=${this.blockNumber}`;
+    return { block: this.blockNumber };
   }
   get blockNumber() {
     return BigInt(this.block);
   }
-  fetchBlock() {
-    return fetchBlock(this.provider, this.block);
+  fetchBlock(): Promise<ReturnType<typeof fetchBlock>> {
+    return this.cache.get('BLOCK', () => fetchBlock(this.provider, this.block));
   }
   override async fetchStateRoot() {
     return (await this.fetchBlock()).stateRoot;
+  }
+  override async fetchTimestamp() {
+    return parseInt((await this.fetchBlock()).timestamp);
   }
   protected abstract _proveNeed(
     need: TargetNeed,


### PR DESCRIPTION
- changed old `/` to `/debug` hidden behind `--debug` flag
- added `/` which shows static config
- added `/delay` which shows `{ timestamp: number, index: HexString, ... }`
- added `AbstractProver.fetchTimestamp()`